### PR TITLE
Looks like `post_command` argument is missing in `minitest--file-command`

### DIFF
--- a/minitest.el
+++ b/minitest.el
@@ -97,7 +97,7 @@ The current directory is assumed to be the project's root otherwise."
   "Run COMMAND on currently visited file."
   (let ((file-name (file-relative-name (buffer-file-name) (minitest-project-root))))
     (if file-name
-	(minitest-run-file file-name)
+	(minitest-run-file file-name post-command)
       (error "Buffer is not visiting a file"))))
 
 (defun minitest--test-name-flag (test-name)


### PR DESCRIPTION
I may be wrong, but I had to do this to get stuff working.