### PR TITLE
Issue with regex when test file contains mix of single and double quotes.

### DIFF
--- a/minitest.el
+++ b/minitest.el
@@ -110,8 +110,7 @@ The current directory is assumed to be the project's root otherwise."
     (save-restriction
       (widen)
       (end-of-line)
-      (or (re-search-backward "\\(test\\) '\\([^\"]+?\\)'" nil t)
-          (re-search-backward "\\(test\\) \"\\([^\"]+?\\)\"" nil t)
+      (or (re-search-backward "\\(test\\) ['\"]\\([^\"]+?\\)['\"]" nil t)
           (re-search-backward "def \\(test\\)_\\([_A-Za-z0-9]+\\)" nil t)
           (re-search-backward "\\(it\\) '\\([^\"]+?\\)'" nil t)
           (re-search-backward "\\(it\\) \"\\([^\"]+?\\)\"" nil t)))))


### PR DESCRIPTION
Example, if your test file looks like this:

```ruby
test '#method says hi' do
  # ..
end

test "#other_method says bye" do
  #..
end
```

... And your cursor is positioned in the second test (`#other_method says bye`), `C-c , s` will run the test above rather, because it matches the 1st regex in the list.