### PR TITLE
No longer provide a feature in test-helper.el

### DIFF
--- a/test/minitest-unit-test.el
+++ b/test/minitest-unit-test.el
@@ -4,8 +4,6 @@
 
 ;;; Code:
 
-(require 'test-helper)
-
 (ert-deftest test-minitest-buffer-name ()
   (let ((filename nil))
     (should (equal (minitest-buffer-name filename) "*Minitest *")))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -21,5 +21,4 @@
 
 (require 'minitest (f-expand "minitest" minitest-test/root-path))
 
-(provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
The file isn't a library intended to be loaded with `require`.
Instead `ert-runner` loads it using `load`.  Other packages that
use `ert-runner` also come with a file named test-helper.el and
unfortunately many of those also provide `test-helper`, which
leads to conflicts.

Also see https://github.com/rejeep/ert-runner.el/issues/38.