### PR TITLE
Add: custom variable for minitest spring command

### DIFF
--- a/minitest.el
+++ b/minitest.el
@@ -64,12 +64,17 @@
   :type 'list
   :group 'minitest)
 
+(defcustom minitest-spring-command '("spring" "rake" "test")
+  "Spring command for minitest"
+  :type 'list
+  :group 'minitest)
+
 (defun minitest-buffer-name (file-or-dir)
   (concat "*Minitest " file-or-dir "*"))
 
 (defun minitest-test-command ()
-  (let ((command (cond (minitest-use-spring '("spring" "rake" "test"))
-                       ((minitest-zeus-p) '("zeus" "test"))
+  (let ((command (cond (minitest-use-spring minitest-spring-command)
+        ((minitest-zeus-p) '("zeus" "test"))
                        (minitest-use-rails '("bin/rails" "test"))
                        (t minitest-default-command))))
     (if minitest-use-docker (append minitest-docker-command (list minitest-docker-container) command)

--- a/minitest.el
+++ b/minitest.el
@@ -75,8 +75,8 @@
 (defun minitest-test-command ()
   (let ((command (cond (minitest-use-spring minitest-spring-command)
         ((minitest-zeus-p) '("zeus" "test"))
-                       (minitest-use-rails '("bin/rails" "test"))
-                       (t minitest-default-command))))
+        (minitest-use-rails '("bin/rails" "test"))
+        (t minitest-default-command))))
     (if minitest-use-docker (append minitest-docker-command (list minitest-docker-container) command)
       command)))
 

--- a/minitest.el
+++ b/minitest.el
@@ -74,9 +74,9 @@
 
 (defun minitest-test-command ()
   (let ((command (cond (minitest-use-spring minitest-spring-command)
-        ((minitest-zeus-p) '("zeus" "test"))
-        (minitest-use-rails '("bin/rails" "test"))
-        (t minitest-default-command))))
+                       ((minitest-zeus-p) '("zeus" "test"))
+                       (minitest-use-rails '("bin/rails" "test"))
+                       (t minitest-default-command))))
     (if minitest-use-docker (append minitest-docker-command (list minitest-docker-container) command)
       command)))
 

--- a/test/minitest-unit-test.el
+++ b/test/minitest-unit-test.el
@@ -35,7 +35,7 @@
 
 (ert-deftest test-minitest-test-command ()
   (let ((minitest-use-spring t))
-    (should (equal (minitest-test-command) (minitest-spring-command))))
+    (should (equal (minitest-test-command) minitest-spring-command)))
   (let ((minitest-use-docker t)
         (minitest-docker-container "app")
         (minitest-use-rails t))

--- a/test/minitest-unit-test.el
+++ b/test/minitest-unit-test.el
@@ -35,7 +35,7 @@
 
 (ert-deftest test-minitest-test-command ()
   (let ((minitest-use-spring t))
-    (should (equal (minitest-test-command) '("spring" "rake" "test"))))
+    (should (equal (minitest-test-command) (minitest-spring-command))))
   (let ((minitest-use-docker t)
         (minitest-docker-container "app")
         (minitest-use-rails t))


### PR DESCRIPTION
This patch makes it configurable by allowing the spring command to be configured externally through the variable `minitest-spring-command`.
This is useful if you have a complicated spring workflow like we have at Zendesk.