### PR TITLE
Fix: minitest--post-command regexp so verify single will work

### DIFF
--- a/minitest.el
+++ b/minitest.el
@@ -140,7 +140,7 @@ The current directory is assumed to be the project's root otherwise."
     (error "No test found. Make sure you are on a file that has `def test_foo` or `test \"foo\"`")))
 
 (defun minitest--post-command (cmd str)
-  (format "%s" (replace-regexp-in-string "[\s#:]" "_" str)))
+  (format "%s" (replace-regexp-in-string "[\s]" "_" str)))
 
 (defun minitest-rerun ()
   "Run the last command"

--- a/test/minitest-unit-test.el
+++ b/test/minitest-unit-test.el
@@ -55,7 +55,7 @@
 
 (ert-deftest test-minitest--post-command ()
   (defvar test-description "#method_name behavior of Module::Class")
-  (defvar method-name "_method_name_behavior_of_Module__Class")
+  (defvar method-name "#method_name_behavior_of_Module::Class")
   (should (equal method-name (minitest--post-command "test" test-description)))
   (should (equal method-name (minitest--post-command "it" test-description))))
 


### PR DESCRIPTION
Tests that contain # or : are not working correctly when running verify-single, because the regexp strips out the # and : characters and the test names no longer match up.

Its possible that this was necessary with earlier versions of Ruby/Minitest.  I'm currently testing this against Minitest 5.11.3 with Ruby 2.6.3.  I have not yet tested this with older versions of minitest, but I could not find anything in the changelog that specifically referenced this behavior.

Perhaps this is operating system specific?  I can verify the change works for me for tests that contain a # or :: now.  I'm not sure if this addresses issue #39 because the behavior there is different.


