### PR TITLE
Remove definition of compilation-scroll-output to allow user customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ If you have yasnippet installed, you can load the snippets:
   '(minitest-install-snippets))
 ```
 
+## Scroll Position
+
+The `compilation-scroll-output` variable, when set to `t`, scrolls to the bottom
+of the test output. When set to `nil`, the test output buffer stays scrolled to
+the top.
+
+Before version 0.10.0, this variable was set to `t` before running tests, but
+after version 0.10.0 it is not set explicitly anymore. In order to get back the
+old behavior, just set `compilation-scroll-output` to `t` yourself.
+
 ## License
 
 The MIT License (MIT)

--- a/minitest.el
+++ b/minitest.el
@@ -4,10 +4,14 @@
 
 ;; Author: Arthur Neves
 ;; URL: https://github.com/arthurnn/minitest-emacs
-;; Version: 0.9.2
+;; Version: 0.10.0
 ;; Package-Requires: ((dash "1.0.0"))
 
 ;; This file is NOT part of GNU Emacs.
+
+;;; Change Log:
+
+;; 0.10.0 - No longer explicitly set compilation-scroll-output
 
 ;;; Code:
 

--- a/minitest.el
+++ b/minitest.el
@@ -114,7 +114,6 @@ The current directory is assumed to be the project's root otherwise."
       (rvm-activate-corresponding-ruby))
 
   (let ((default-directory (minitest-project-root))
-        (compilation-scroll-output t)
         (actual-command (concat (or minitest-default-env "") " " command)))
     (setq minitest--last-command (list command file-name))
     (compilation-start


### PR DESCRIPTION
By explicitly setting compilation-scroll-output, users can't set it to the value they prefer. If we don't set it, users who like scrolling to the bottom can enable it, whereas users who don't can set it to nil.

No matter how I've tried setting this variable (hooks, finish-functions, etc) if it is explicitly set like this I haven't been able to change it. Perhaps there is a strategy that I'm missing, but this seems like an easy fix that would open up more user customization.